### PR TITLE
Add Django to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django-appconf
+django>=1.11.0

--- a/tox.ini
+++ b/tox.ini
@@ -27,5 +27,4 @@ whitelist_externals=make
 changedir={toxinidir}/docs
 deps=
     -rrequirements-dev.txt
-    https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
 commands=make spelling


### PR DESCRIPTION
readthedocs.io needs Django in the requirements file.