### PR TITLE
Fix migration options

### DIFF
--- a/heroku_connect/utils.py
+++ b/heroku_connect/utils.py
@@ -94,7 +94,7 @@ def create_heroku_connect_schema(using=DEFAULT_DB_ALIAS, **kwargs):
 
         cursor.execute("CREATE SCHEMA %s;" % settings.HEROKU_CONNECT_SCHEMA)
 
-        with connection.schema_editor() as editor:
-            for model in get_heroku_connect_models():
-                editor.create_model(model)
+    with connection.schema_editor() as editor:
+        for model in get_heroku_connect_models():
+            editor.create_model(model)
     return True


### PR DESCRIPTION
Make sure `managed=False` is always added to the Heroku Connect models
since the migration state will only pick up explicitly created Meta
attributes.