### PR TITLE
Make id field nullable or unique by kwargs

### DIFF
--- a/heroku_connect/db/models/fields.py
+++ b/heroku_connect/db/models/fields.py
@@ -60,9 +60,9 @@ class ID(HerokuConnectFieldMixin, models.CharField):
 
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 18
-        kwargs['unique'] = True
         kwargs['editable'] = False
-        kwargs['null'] = False
+        kwargs.setdefault('unique', True)
+        kwargs.setdefault('null', False)
         super().__init__(*args, **kwargs)
 
 

--- a/heroku_connect/db/models/fields.py
+++ b/heroku_connect/db/models/fields.py
@@ -61,8 +61,8 @@ class ID(HerokuConnectFieldMixin, models.CharField):
     def __init__(self, *args, **kwargs):
         kwargs['max_length'] = 18
         kwargs['editable'] = False
+        kwargs['null'] = True
         kwargs.setdefault('unique', True)
-        kwargs.setdefault('null', False)
         super().__init__(*args, **kwargs)
 
 

--- a/tests/db/models/test_fields.py
+++ b/tests/db/models/test_fields.py
@@ -65,9 +65,9 @@ class TestID:
 
     def test_null(self):
         field = field_factory(hc_models.ID)
-        assert field.null is False
+        assert field.null is True
 
-        field = field_factory(hc_models.ID, null=True)
+        field = field_factory(hc_models.ID, null=False)
         assert field.null is True
 
 

--- a/tests/db/models/test_fields.py
+++ b/tests/db/models/test_fields.py
@@ -54,7 +54,7 @@ class TestID:
         assert field.unique is True
 
         field = field_factory(hc_models.ID, unique=False)
-        assert field.unique is True
+        assert field.unique is False
 
     def test_editable(self):
         field = field_factory(hc_models.ID)
@@ -65,10 +65,10 @@ class TestID:
 
     def test_null(self):
         field = field_factory(hc_models.ID)
-        assert field.editable is False
+        assert field.null is False
 
         field = field_factory(hc_models.ID, null=True)
-        assert field.editable is False
+        assert field.null is True
 
 
 class TestNumber:


### PR DESCRIPTION
* In some cases an ID field is there but it's not unique since it's a reference to some other object.
* about the nullable flag, whenever you create a new object that needs to be synced to salesforce, initially ID(`sf_id`) is `null`, then when heroku connect syncs it, it fills it out...