### PR TITLE
Fix Picklist max_length

### DIFF
--- a/heroku_connect/db/models/fields.py
+++ b/heroku_connect/db/models/fields.py
@@ -222,7 +222,8 @@ class Picklist(HerokuConnectFieldMixin, models.CharField):
         self.choices = kwargs['choices']
         longest_choice = max(self.flatchoices, key=lambda choice: len(choice[0]))
         max_length = len(longest_choice[0])
-        kwargs['max_length'] = max_length
+        max_length = max(255, max_length)
+        kwargs.setdefault('max_length', max_length)
         super().__init__(*args, **kwargs)
 
 

--- a/tests/db/models/test_fields.py
+++ b/tests/db/models/test_fields.py
@@ -174,7 +174,7 @@ class TestPicklist:
             ('12', '12'),
         )
         field = field_factory(hc_models.Picklist, choices=choices)
-        assert field.max_length == 3
+        assert field.max_length == 255
 
         choices = (
             ('group1', (
@@ -187,7 +187,11 @@ class TestPicklist:
              ),
         )
         field = field_factory(hc_models.Picklist, choices=choices)
-        assert field.max_length == 3
+        assert field.max_length == 255
 
         field = field_factory(hc_models.Picklist, max_length=42, choices=choices)
-        assert field.max_length == 3
+        assert field.max_length == 42
+
+        field = field_factory(hc_models.Picklist,
+                              choices=[(''.join(str(i) for i in range(1000)), 'long option')])
+        assert field.max_length == 2890


### PR DESCRIPTION
Picklists seem to be mapped to at least varchar(255) even if the
choices are shorter.