### PR TITLE
Fix migrations -- Add missing table name

### DIFF
--- a/tests/db/models/test_base.py
+++ b/tests/db/models/test_base.py
@@ -57,6 +57,7 @@ class TestHerokuConnectModelMixin:
             migration = f.read()
         shutil.rmtree(os.path.join(settings.BASE_DIR, 'testapp/migrations'))
         assert "'managed': False," in migration
+        assert "'db_table': 'salesforce\".\"number_object__c'," in migration
 
     def test_empty_mapping(self):
         class MyModel(hc_models.HerokuConnectModel):


### PR DESCRIPTION
Django migrations do not call the models meta calls but only use
the options defined in the migration. Should someone add constraints
to a heroku connect model, this will fail because the migration
state of the Heroku Connect model does not reflect the actual
table name.