### PR TITLE
Run create schema command only when test db is created

### DIFF
--- a/heroku_connect/db/backends/base/creation.py
+++ b/heroku_connect/db/backends/base/creation.py
@@ -6,10 +6,13 @@ from django.db.models.signals import pre_migrate
 from heroku_connect.utils import create_heroku_connect_schema
 
 
+def _create_heroku_connect_schema(sender, app_config, **kwargs):
+    create_heroku_connect_schema(using=kwargs['using'])
+    assert pre_migrate.disconnect(_create_heroku_connect_schema)
+
+
 class DatabaseCreation(_DatabaseCreation):
 
     def create_test_db(self, *args, **kwargs):
-        pre_migrate.connect(create_heroku_connect_schema)
-        test_database_name = super().create_test_db(*args, **kwargs)
-        assert pre_migrate.disconnect(create_heroku_connect_schema)
-        return test_database_name
+        pre_migrate.connect(_create_heroku_connect_schema)
+        return super().create_test_db(*args, **kwargs)

--- a/heroku_connect/utils.py
+++ b/heroku_connect/utils.py
@@ -88,7 +88,7 @@ SELECT exists(
 """
 
 
-def create_heroku_connect_schema(using=DEFAULT_DB_ALIAS, **kwargs):
+def create_heroku_connect_schema(using=DEFAULT_DB_ALIAS):
     """
     Create Heroku Connect schema.
 


### PR DESCRIPTION
Django's pre_migrate singal is called once of each app. The signal
receiver needs to handle this fact and only act if it was called
for the Heroku Connect app.