### PR TITLE
Don't autocreate AUTHORS and ChangeLog

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,10 @@ keywords =
 [files]
 packages =
     heroku_connect
+    
+[pbr]
+skip_authors = true
+skip_changelog = true
 
 [tool:pytest]
 norecursedirs = env .tox .eggs


### PR DESCRIPTION
Git isn't tracking these files, so if `openstack-dev/pbr` autocreates them, they end up as unstaged changes in the local working tree. This change tells `pbr` to stop this madness.