### PR TITLE
Don't run deploy for every travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ jobs:
     - stage: PyPI release  # will run after the default "test" stage succeeds
       script: echo "Deploying to PyPI ..."  # override regular test script; "skip" should also work
       env: TOXENV=isort  # if not set explicitly, build matrix vars will use their first value
+      if: tag IS present
       deploy:
         provider: pypi
         user: codingjoe

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,18 @@ script:
 - tox -e $TOXENV
 after_success:
 - codecov
-deploy:
-  provider: pypi
-  user: codingjoe
-  password:
-    secure: jJSnEnmQgSJasFJkzvdf4SEC8l2FDHQGFp71lGdcbwx0jUEHQm2G13LDVrK31J8iQyk3jlnVJz9EA3MD3P2L06aOcj+71iG6/jtSLfECwRbc1FqltGy7Q746Wcgq+AaBpJq7qCzY/RK2WO1VDXgiyy1xr/2NpldlrGN43Ba9rs8E/ej6WpBeyBC+yCilRGQallLqHXYGHVD3Udsd+QAj0UsenXOtpw0Rz4UZHcphDLKmUIWiAqR+ibbcdyCbm8iLdXMNneDbGHdEWFiiO6hOLEuiG0FY06CTOH/DCqOV2spZTbG5TPk+iURjiI/x+K0AKFKe0Re9889lydQbe9mXjhQ9foU9dI9PS99MM4aTe7LPYWN9fCZV6CeSSlvV7ogwFuPIT51xU2VP9IA5Io103UmDbJcG/HxGwdL7/hEKJgdjxcwG8CpZrWwZl/Xsu6NoBE7CE8mbnwLkcjRs20oWapXUbwml4+5dA3XM41opzt3CXIDT2lo/kVZ/z+VlSpxqu3O3MOGgT6ywN+l+PXOjSTSbPaTmp6xjVBc8BMGRWabxpafXjBNoQfpN99TuX1iLKQXb1XNKxCCpKdUXt76RVdCpkgDMga/2rauxvfIU3URdH16uCxsMFXx+CsGums5esChZRaOFq1z80DrYyX/91wB5bxYRKyM34XplmvQ2JQo=
-  on:
-    tags: true
-    distributions: sdist bdist_wheel
-    repo: Thermondo/django-heroku-connect
-    branch: master
+jobs:
+  include:
+    - stage: PyPI release  # will run after the default "test" stage succeeds
+      script: echo "Deploying to PyPI ..."  # override regular test script; "skip" should also work
+      env: TOXENV=isort  # if not set explicitly, build matrix vars will use their first value
+      deploy:
+        provider: pypi
+        user: codingjoe
+        password:
+          secure: jJSnEnmQgSJasFJkzvdf4SEC8l2FDHQGFp71lGdcbwx0jUEHQm2G13LDVrK31J8iQyk3jlnVJz9EA3MD3P2L06aOcj+71iG6/jtSLfECwRbc1FqltGy7Q746Wcgq+AaBpJq7qCzY/RK2WO1VDXgiyy1xr/2NpldlrGN43Ba9rs8E/ej6WpBeyBC+yCilRGQallLqHXYGHVD3Udsd+QAj0UsenXOtpw0Rz4UZHcphDLKmUIWiAqR+ibbcdyCbm8iLdXMNneDbGHdEWFiiO6hOLEuiG0FY06CTOH/DCqOV2spZTbG5TPk+iURjiI/x+K0AKFKe0Re9889lydQbe9mXjhQ9foU9dI9PS99MM4aTe7LPYWN9fCZV6CeSSlvV7ogwFuPIT51xU2VP9IA5Io103UmDbJcG/HxGwdL7/hEKJgdjxcwG8CpZrWwZl/Xsu6NoBE7CE8mbnwLkcjRs20oWapXUbwml4+5dA3XM41opzt3CXIDT2lo/kVZ/z+VlSpxqu3O3MOGgT6ywN+l+PXOjSTSbPaTmp6xjVBc8BMGRWabxpafXjBNoQfpN99TuX1iLKQXb1XNKxCCpKdUXt76RVdCpkgDMga/2rauxvfIU3URdH16uCxsMFXx+CsGums5esChZRaOFq1z80DrYyX/91wB5bxYRKyM34XplmvQ2JQo=
+        on:
+          tags: true
+          distributions: sdist bdist_wheel
+          repo: Thermondo/django-heroku-connect
+          branch: master


### PR DESCRIPTION
Using a different build stage stops the travis deploy command from running for every build in the build matrix. 

This could also be accomplished by using a condition on the deploy to limit it to one build; however, then the deployment would take place even if other builds fail. The deploy stage, on the other hand, waits for the previous testing stage to succeed.

Note:
* this travis feature is still in beta;
* I didn't test this;
* I *did* try https://lint.travis-ci.org/, but it's outdated and doesn't recognize the "jobs" key.
* Let's see what travis thinks about the `.travis.yml` in this PR. 

See also:
https://docs.travis-ci.com/user/build-stages/
https://docs.travis-ci.com/user/build-stages/matrix-expansion/
https://docs.travis-ci.com/user/build-stages/deploy-github-releases/