### PR TITLE
Add database router to prevent write actions on read-only tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# pytest
+.pytest_cache/

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1,0 +1,5 @@
+Exceptions
+==========
+
+.. automodule:: heroku_connect.db.exceptions
+    :members:

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -20,6 +20,10 @@ Simply install the PyPi package…
 
 …and add ``heroku_connect`` to the ``INSTALLED_APP`` settings.
 
+You can add :class:`heroku_connect.db.router.HerokuConnectRouter<.HerokuConnectRouter>` to
+your ``DATABASE_ROUTERS`` setting, to make prevent your from
+write access errors.
+
 Last but not least make sure to change the database engine, e.g.:
 
 .. code:: python

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -21,7 +21,7 @@ Simply install the PyPi package…
 …and add ``heroku_connect`` to the ``INSTALLED_APP`` settings.
 
 You can add :class:`heroku_connect.db.router.HerokuConnectRouter<.HerokuConnectRouter>` to
-your ``DATABASE_ROUTERS`` setting, to make prevent your from
+your ``DATABASE_ROUTERS`` setting, to prevent you from making
 write access errors.
 
 Last but not least make sure to change the database engine, e.g.:

--- a/docs/router.rst
+++ b/docs/router.rst
@@ -1,0 +1,5 @@
+Router
+======
+
+.. automodule:: heroku_connect.db.router
+    :members:

--- a/heroku_connect/db/exceptions.py
+++ b/heroku_connect/db/exceptions.py
@@ -1,0 +1,9 @@
+from django.db import NotSupportedError
+
+__all__ = ('WriteNotSupportedError',)
+
+
+class WriteNotSupportedError(NotSupportedError):
+    """Write actions are not supported on read-only tables."""
+
+    pass

--- a/heroku_connect/db/models/base.py
+++ b/heroku_connect/db/models/base.py
@@ -1,12 +1,14 @@
-from functools import wraps
-
 from django.core import checks
 from django.db import models
 
 from . import fields
 from ...conf import settings
 
-__all__ = ('HerokuConnectModel',)
+__all__ = ('HerokuConnectModel', 'READ_ONLY', 'READ_WRITE')
+
+
+READ_ONLY = 'read_only'
+READ_WRITE = 'read_write'
 
 
 class HerokuConnectModelBase(models.base.ModelBase):
@@ -108,7 +110,7 @@ class HerokuConnectModel(models.Model, metaclass=HerokuConnectModelBase):
     sf_object_name = ''
     """Salesforce object API name."""
 
-    sf_access = 'read_only'
+    sf_access = READ_ONLY
     """
     Heroku Connect Object access level.
 
@@ -227,7 +229,7 @@ class HerokuConnectModel(models.Model, metaclass=HerokuConnectModelBase):
 
     @classmethod
     def _check_sf_access(cls):
-        allowed_access_types = ['read_only', 'read_write']
+        allowed_access_types = [READ_ONLY, READ_WRITE]
         if cls.sf_access not in allowed_access_types:
             return [checks.Error(
                 "%s.%s.sf_access must be one of %s" % (

--- a/heroku_connect/db/router.py
+++ b/heroku_connect/db/router.py
@@ -11,8 +11,8 @@ class HerokuConnectRouter:
     methods are called on read-only tables.
 
     .. note::
-        You will need to enable add the router to your ``DATABASE_ROUTERS``
-        setting. For example::
+        You will need to add the router to your ``DATABASE_ROUTERS`` setting.
+        For example::
 
             DATABASE_ROUTERS = ['heroku_connect.db.router.HerokuConnectRouter']
 

--- a/heroku_connect/db/router.py
+++ b/heroku_connect/db/router.py
@@ -1,0 +1,39 @@
+from .exceptions import WriteNotSupportedError
+from .models import READ_ONLY
+
+
+class HerokuConnectRouter:
+    """
+    Router that prevents write actions on read-only Heroku Connect tables.
+
+    The router will raise a :class:`.WriteNotSupportedError` error when
+    ``save``, ``create``, ``delete``, ``update`` or other model or QuerySet
+    methods are called on read-only tables.
+
+    .. note::
+        You will need to enable add the router to your ``DATABASE_ROUTERS``
+        setting. For example::
+
+            DATABASE_ROUTERS = ['heroku_connect.db.router.HerokuConnectRouter']
+
+    .. seealso:: `Automatic database routing`_
+
+    .. _Automatic database routing:
+        https://docs.djangoproject.com/en/stable/topics/db/multi-db/#automatic-database-routing
+
+    """
+
+    def db_for_write(self, model, **hints):
+        """
+        Prevent write actions on read-only tables.
+
+        Raises:
+            WriteNotSupportedError: If models.sf_access is ``read_only``.
+
+        """
+        try:
+            if model.sf_access == READ_ONLY:
+                raise WriteNotSupportedError("%r is a read-only model." % model)
+        except AttributeError:
+            pass
+        return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from django.db import connection
 from django.utils import timezone
 
-from heroku_connect.db.models.base import HerokuConnectModel
+from heroku_connect.db.models.base import READ_WRITE, HerokuConnectModel
 from heroku_connect.models import (
     TRIGGER_LOG_ACTION, TRIGGER_LOG_STATE, TriggerLog, TriggerLogArchive
 )
@@ -44,6 +44,7 @@ def connected_class():
         # define the class only once, or django will warn about redefining models
         class ConnectedTestModel(HerokuConnectModel):
             sf_object_name = 'CONNECTED_TEST_MODEL'
+            sf_access = READ_WRITE
 
             class Meta:
                 app_label = 'tests'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,7 +58,7 @@ def test_get_mapping(settings):
         'mappings': [
             {
                 'config': {
-                    'access': 'read_only',
+                    'access': 'read_write',
                     'fields': {
                         'A_Number__c': {},
                         'External_ID': {},
@@ -80,7 +80,7 @@ def test_get_mapping(settings):
             },
             {
                 'config': {
-                    'access': 'read_only',
+                    'access': 'read_write',
                     'fields': {
                         'A_DateTime__c': {},
                         'Id': {},
@@ -104,7 +104,7 @@ def test_get_mapping(settings):
     assert utils.get_mapping()['mappings'] == [
         {
             'config': {
-                'access': 'read_only',
+                'access': 'read_write',
                 'fields': {
                     'A_Number__c': {},
                     'External_ID': {},
@@ -126,7 +126,7 @@ def test_get_mapping(settings):
         },
         {
             'config': {
-                'access': 'read_only',
+                'access': 'read_write',
                 'fields': {
                     'A_DateTime__c': {},
                     'Id': {},

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -13,6 +13,7 @@ def frozen_uuid_generator():
 
 
 class NumberModel(hc_models.HerokuConnectModel):
+    sf_access = hc_models.READ_WRITE
     sf_object_name = 'Number_Object__c'
 
     a_number = hc_models.Number(_('yet another number'), sf_field_name='A_Number__c',
@@ -29,6 +30,7 @@ class OtherModel(models.Model):
 
 
 class DateTimeModel(hc_models.HerokuConnectModel):
+    sf_access = hc_models.READ_WRITE
     sf_object_name = 'DateTime_Object__c'
 
     a_datetime = hc_models.DateTime(_('a date time field'), sf_field_name='A_DateTime__c')

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -77,6 +77,8 @@ DATABASES = {
     }
 }
 
+DATABASE_ROUTERS = ['heroku_connect.db.router.HerokuConnectRouter']
+
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators


### PR DESCRIPTION
Raise `WriteNotSupportedError` if both model and QuerySet methods
are called that try to perform write actions on read-only mappings.