### PR TITLE
Fix setup instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,33 +19,6 @@ Documentation
 Check out the full documentation at here:
 https://django-heroku-connect.readthedocs.io/
 
-Install
--------
-
-Simply install the PyPi package…
-
-.. code:: shell
-
-    pip install django-heroku-connect
-
-…and add ``heroku_connect`` to the ``INSTALLED_APP`` settings.
-
-Last but not least make sure change the database engine, e.g.:
-
-.. code:: python
-
-    import dj_database_url
-
-    DATABASES['default'] = dj_database_url.config(
-        engine='heroku_connect.db.backends.postgresql'
-    )
-
-    # or for PostGIS support:
-
-    DATABASES['default'] = dj_database_url.config(
-        engine='heroku_connect.db.backends.postgis'
-    )
-
 
 .. |version| image:: https://img.shields.io/pypi/v/django-heroku-connect.svg
    :target: https://pypi.python.org/pypi/django-heroku-connect/

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Last but not least make sure change the database engine, e.g.:
     import dj_database_url
 
     DATABASES['default'] = dj_database_url.config(
-        engine='heroku_connect.db.backends.postgres'
+        engine='heroku_connect.db.backends.postgresql'
     )
 
     # or for PostGIS support:

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -31,7 +31,7 @@ Last but not least make sure to change the database engine, e.g.:
     import dj_database_url
 
     DATABASES['default'] = dj_database_url.config(
-        engine='heroku_connect.db.backends.postgres'
+        engine='heroku_connect.db.backends.postgresql'
     )
 
     # or for PostGIS support:


### PR DESCRIPTION
Hi,

While setting this up I encountered a problem, found out that we have a small bug in setup instructions.
Instructions refer to `heroku_connect.db.backends.postgres`, but the package has slightly different path:
https://github.com/Thermondo/django-heroku-connect/tree/master/heroku_connect/db/backends/postgresql
