### PR TITLE
Auto-create trigger log tables only when necessary.

### DIFF
--- a/heroku_connect/db/backends/base/creation.py
+++ b/heroku_connect/db/backends/base/creation.py
@@ -1,11 +1,9 @@
 from django.db.backends.postgresql.creation import (
     DatabaseCreation as _DatabaseCreation
 )
-from django.db.models.signals import post_migrate, pre_migrate
+from django.db.models.signals import pre_migrate
 
-from heroku_connect.utils import (
-    create_heroku_connect_schema, create_trigger_log_tables
-)
+from heroku_connect.utils import create_heroku_connect_schema
 
 
 def _create_heroku_connect_schema(sender, app_config, **kwargs):
@@ -13,14 +11,8 @@ def _create_heroku_connect_schema(sender, app_config, **kwargs):
     assert pre_migrate.disconnect(_create_heroku_connect_schema)
 
 
-def _create_trigger_log_models(sender, app_config, **kwargs):
-    create_trigger_log_tables(using=kwargs['using'])
-    assert post_migrate.disconnect(_create_trigger_log_models)
-
-
 class DatabaseCreation(_DatabaseCreation):
 
     def create_test_db(self, *args, **kwargs):
         pre_migrate.connect(_create_heroku_connect_schema)
-        post_migrate.connect(_create_trigger_log_models)
         return super().create_test_db(*args, **kwargs)

--- a/heroku_connect/migrations/0001_initial.py
+++ b/heroku_connect/migrations/0001_initial.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import django.contrib.postgres.fields.hstore
-from django.contrib.postgres.operations import HStoreExtension
 from django.db import migrations, models
 
 
@@ -17,7 +16,6 @@ class Migration(migrations.Migration):
         # TriggerLog models and operations use the postgres hstore extension
         # Heroku (Connect) should take care that it's installed, however we need to create it
         # manually in the test database.
-        HStoreExtension(),  # Need superuser privileges, which is the case for Heroku
         migrations.CreateModel(
             name='TriggerLog',
             fields=[

--- a/heroku_connect/utils.py
+++ b/heroku_connect/utils.py
@@ -131,6 +131,10 @@ def create_heroku_connect_schema(using=DEFAULT_DB_ALIAS):
     with connection.schema_editor() as editor:
         for model in get_heroku_connect_models():
             editor.create_model(model)
+
+        # Needs PostgreSQL and database superuser privileges (which is the case on Heroku):
+        editor.execute('CREATE EXTENSION IF NOT EXISTS "hstore";')
+
         from heroku_connect.models import (TriggerLog, TriggerLogArchive)
         for cls in [TriggerLog, TriggerLogArchive]:
             editor.create_model(cls)

--- a/heroku_connect/utils.py
+++ b/heroku_connect/utils.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 from psycopg2.extensions import AsIs
 
 from .conf import settings
-from .db.models.base import get_heroku_connect_table_name
 
 
 class ConnectionStates:
@@ -101,14 +100,6 @@ SELECT exists(
     );
 """
 
-_TABLE_EXISTS_QUERY = """
-SELECT EXISTS (
-    SELECT 1
-    FROM pg_tables
-    WHERE schemaname = %(schema)s AND tablename = %(table)s
-);
-"""
-
 
 def create_heroku_connect_schema(using=DEFAULT_DB_ALIAS):
     """
@@ -140,40 +131,7 @@ def create_heroku_connect_schema(using=DEFAULT_DB_ALIAS):
     with connection.schema_editor() as editor:
         for model in get_heroku_connect_models():
             editor.create_model(model)
-    return True
-
-
-def create_trigger_log_tables(using=DEFAULT_DB_ALIAS):
-    """
-    Create the tables for the trigger log models in :mod:`heroku_connect.models`.
-
-    Creating these tables manually should only be necessary for a local database.
-    In a production environment, they are created and managed by Heroku Connect.
-
-    Args:
-        using (str): Alias for database connection.
-
-    Returns:
-        bool: ``True`` if the tables were created, ``False`` if they already exist.
-
-    Raises:
-        DatabaseError: if any of the tables already exists.
-
-    """
-    from heroku_connect.models import (TriggerLog, TriggerLogArchive)
-    connection = connections[using]
-
-    with connection.cursor() as cursor:
-        params = {
-            'schema': settings.HEROKU_CONNECT_SCHEMA,
-            'table': get_heroku_connect_table_name(TriggerLog),
-        }
-        cursor.execute(_TABLE_EXISTS_QUERY, params)
-        table_exists = cursor.fetchone()[0]
-        if table_exists:
-            return False
-
-    with connection.schema_editor() as editor:
+        from heroku_connect.models import (TriggerLog, TriggerLogArchive)
         for cls in [TriggerLog, TriggerLogArchive]:
             editor.create_model(cls)
     return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ warning-is-error = 1
 
 [tool:pytest]
 norecursedirs = env .tox .eggs
-addopts = --tb=short -rxs
+addopts = --tb=short -rxs --nomigrations
 DJANGO_SETTINGS_MODULE=tests.testapp.settings
 
 [pycodestyle]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -211,3 +211,7 @@ def test_get_connected_model_for_table_name(db, connected_class):
 
     with pytest.raises(LookupError):
         utils.get_connected_model_for_table_name("NOBODY'S_TABLE_NAME")
+
+
+def test_create_trigger_log_tables(db):
+    assert not utils.create_trigger_log_tables(), 'Trigger log tables should have been autocreated'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -211,7 +211,3 @@ def test_get_connected_model_for_table_name(db, connected_class):
 
     with pytest.raises(LookupError):
         utils.get_connected_model_for_table_name("NOBODY'S_TABLE_NAME")
-
-
-def test_create_trigger_log_tables(db):
-    assert not utils.create_trigger_log_tables(), 'Trigger log tables should have been autocreated'


### PR DESCRIPTION
This fixes a ProgrammingError when running tests with `--reuse-db`, where `create_test_db` would attempt to create the trigger log tables even though they already exist.