### PR TITLE
Do not sleep in test_import_mappings

### DIFF
--- a/tests/commands/test_import_mappings.py
+++ b/tests/commands/test_import_mappings.py
@@ -83,7 +83,10 @@ class TestImportMapping:
         )
         with io.StringIO() as stdout:
             with pytest.raises(CommandError) as e:
-                call_command('import_mappings', '--app', 'ninja', stdout=stdout)
+                call_command('import_mappings',
+                             '--app', 'ninja',
+                             '--wait-interval', '0',  # don't need to wait when mocking calls
+                             stdout=stdout)
             stdout.seek(0)
             console = stdout.read()
         assert ("No associated connections found"


### PR DESCRIPTION
There's no need to have the test sleep for 10 seconds between mocked requests.