### PR TITLE
Add admin actions to ignore and retry failed logs

### DIFF
--- a/docs/error_handling.rst
+++ b/docs/error_handling.rst
@@ -23,6 +23,26 @@ procedures provided by Heroku Connect to `fix sync errors`_.
 .. _fix sync errors:
   https://devcenter.heroku.com/articles/writing-data-to-salesforce-with-heroku-connect#write-errors
 
+
+Admin actions
+^^^^^^^^^^^^^
+
+The admins for the trigger log models (discussed below) offer actions to *ignore* or *retry* failed
+trigger log entries. The former simply sets the state of the entry to ``IGNORED``, if you want to
+clean up for whatever reason.
+
+*Retrying* means an attempt to re-sync the change represented by the trigger log. This entails
+creating an identical trigger log row in ``NEW`` state, either by simply changing the failed
+row's state (:class:`.TriggerLog`), or by copying an archived row back into
+the live TriggerLog and setting the archived state to ``REQUEUED``
+(:class:`.TriggerLogArchive`). Heroku Connect will then normally process that
+row.
+
+If this simple attempt at a fix does not work, try to manually call
+:meth:`capture_insert() <.TriggerLogAbstract.capture_insert>` or
+:meth:`capture_update() <.TriggerLogAbstract.capture_update>` on a failed trigger log instance.
+
+
 Models
 ^^^^^^
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,9 +16,13 @@ def make_trigger_log_for_model(model, *, is_archived=False, **kwargs):
     return log
 
 
-def make_trigger_log(*, is_archived, **attrs):
+def make_trigger_log(*, is_archived=False, **attrs):
     """
     Make an unsaved trigger log instance from given attributes.
+
+    Args:
+        is_archived (bool): Make a TriggerLog instance if ``True``, a TriggerLogArchive otherwise
+        **attrs: Attributes of the trigger log instance
 
     Returns:
         An unsaved TriggerLog or TriggerLogArchive instance, depending on whether `is_archived`
@@ -27,6 +31,8 @@ def make_trigger_log(*, is_archived, **attrs):
     model_cls = TriggerLogArchive if is_archived else TriggerLog
     attrs.setdefault('state', TRIGGER_LOG_STATE['NEW'])
     attrs.setdefault('action', TRIGGER_LOG_ACTION['INSERT'])
+    attrs.setdefault('table_name', 'SOME_TABLE')
+    attrs.setdefault('record_id', 12345)
     return model_cls(**attrs)
 
 


### PR DESCRIPTION
The trigger log `state` is no longer editable in the admin. Instead, there are list actions that allow retrying failed log actions:

* `TriggerLog` entries have their state set to `NEW`.
* `TriggerLogArchive` entries get copied into `NEW` trigger log rows and set to `REQUEUED`.

This is basically the recovery procedure from the [docs] for the merged write algorithm; it also works in a lot of cases for the ordered-writes algorithm. If it doesn't work, it's still possible to run `log.capture_insert` or `log.capture_update` in the console.

[docs]: https://devcenter.heroku.com/articles/writing-data-to-salesforce-with-heroku-connect#merged-writes-algorithm


It's also possible set FAILED logs to IGNORED, effectively silencing the errors in the web dashboard.