### PR TITLE
Fix Django 3.0 deprecation warning for from_db_value

### DIFF
--- a/heroku_connect/db/models/fields.py
+++ b/heroku_connect/db/models/fields.py
@@ -103,7 +103,7 @@ class ExternalID(HerokuConnectFieldMixin, models.UUIDField):
             value = self.to_python(value)
         return value.hex
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, *args, **kwargs):
         return self.to_python(value)
 
 
@@ -139,7 +139,7 @@ class Number(HerokuConnectFieldMixin, models.DecimalField):
             value = float(self.to_python(value))
         return value
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, *args, **kwargs):
         return self.to_python(value)
 
 


### PR DESCRIPTION
See also: https://github.com/django/django/commit/487362fa8f23d41de4db58e7408e66eb36399af0