### PR TITLE
Revisit CI config: add tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ python:
 services:
   - postgresql
 addons:
+  postgresql: '10'
   apt:
     packages:
       - python3-enchant
       - graphviz
-      - postgresql-9.6-postgis-2.3
-  postgresql: '9.6'
+      - postgresql-10-postgis-2.5
 env:
   matrix:
     - TOXENV=isort
@@ -34,6 +34,7 @@ install:
   - pip install tox-travis
   - pip install -U codecov
 before_script:
+  - psql template1 -c "create extension postgis;"
   - createdb heroku_connect_test
 script:
   - tox -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,6 @@ addons:
       - python3-enchant
       - graphviz
       - postgresql-10-postgis-2.5
-env:
-  matrix:
-    - TOXENV=isort
-    - TOXENV=docs
-    - DJANGO=111
-    - DJANGO=20
-    - DJANGO=21
-    - DJANGO=master
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
   - apt
 python:
   - '3.6'
-  - '3.7'
 services:
   - postgresql
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,44 @@
+dist: bionic
 language: python
 branches:
   only:
-  - master
+    - master
 cache:
-- pip
-- apt
+  - pip
+  - apt
 python:
-- '3.6'
+  - '3.6'
+  - '3.7'
 services:
-- postgresql
+  - postgresql
 addons:
   apt:
     packages:
-    - python3-enchant
-    - graphviz
-    - postgresql-9.6-postgis-2.3
+      - python3-enchant
+      - graphviz
+      - postgresql-9.6-postgis-2.3
   postgresql: '9.6'
 env:
   matrix:
-  - TOXENV=isort
-  - TOXENV=docs
-  - DJANGO=111
-  - DJANGO=20
-  - DJANGO=21
-  - DJANGO=master
+    - TOXENV=isort
+    - TOXENV=docs
+    - DJANGO=111
+    - DJANGO=20
+    - DJANGO=21
+    - DJANGO=master
 matrix:
   fast_finish: true
   allow_failures:
-  - env: DJANGO=master
+    - env: DJANGO=master
 install:
-- pip install --upgrade pip tox
-- pip install -U codecov
+  - pip install tox-travis
+  - pip install -U codecov
 before_script:
-- createdb heroku_connect_test
-- |
-  if [[ -z $TOXENV ]]; then
-    export TOXENV=py$(echo $TRAVIS_PYTHON_VERSION | sed -e 's/\.//g')-dj$DJANGO
-  fi
-- echo $TOXENV
+  - createdb heroku_connect_test
 script:
-- tox -e $TOXENV
+  - tox -v
 after_success:
-- codecov
+  - codecov
 jobs:
   include:
     - stage: PyPI release  # will run after the default "test" stage succeeds

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ addons:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: DJANGO=master
+    - env: TOXENV=py36-djmaster
+    - env: TOXENV=py36-dj30
 install:
   - pip install tox-travis
   - pip install -U codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: TOXENV=py36-djmaster
-    - env: TOXENV=py36-dj30
 install:
   - pip install tox-travis
   - pip install -U codecov

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ https://django-heroku-connect.readthedocs.io/
 
 .. |version| image:: https://img.shields.io/pypi/v/django-heroku-connect.svg
    :target: https://pypi.python.org/pypi/django-heroku-connect/
-.. |ci| image:: https://api.travis-ci.org/Thermondo/django-heroku-connect.svg?branch=master
-   :target: https://travis-ci.org/Thermondo/django-heroku-connect
+.. |ci| image:: https://travis-ci.com/Thermondo/django-heroku-connect.svg?branch=master
+   :target: https://travis-ci.com/Thermondo/django-heroku-connect
 .. |coverage| image:: https://codecov.io/gh/Thermondo/django-heroku-connect/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/Thermondo/django-heroku-connect
 .. |license| image:: https://img.shields.io/badge/license-Apache_2-blue.svg

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37}-dj{111,20,21,22,30,master}
+    py{36}-dj{111,20,21,22,30,master}
     isort
     docs
 whitelist_externals=sphinx-build
@@ -9,7 +9,6 @@ whitelist_externals=sphinx-build
 unignore_outcomes = True
 python =
     3.6: py36,isort,docs
-    3.7: py37
 
 [testenv]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,24 @@
 [tox]
-envlist = py{36}-dj{111,20,21,master},isort,docs
+envlist =
+    py{36,37}-dj{111,20,21,22,30,master}
+    isort
+    docs
 whitelist_externals=sphinx-build
+
+[travis]
+unignore_outcomes = True
+python =
+    3.6: py36,isort,docs
+    3.7: py37
+
 [testenv]
 deps=
     -rrequirements-dev.txt
-    dj111: https://github.com/django/django/archive/stable/1.11.x.tar.gz#egg=django
-    dj20: https://github.com/django/django/archive/stable/2.0.x.tar.gz#egg=django
-    dj21: https://github.com/django/django/archive/stable/2.1.x.tar.gz#egg=django
+    dj111: django>=1.11,<2.0
+    dj20: django>=2.0a1,<2.1
+    dj21: django>=2.1a1,<2.2
+    dj22: django>=2.2a1,<3.0
+    dj30: django>=3.0a1,<3.1
     djmaster: https://github.com/django/django/archive/master.tar.gz#egg=django
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
1. This PR **adds official Travis package, called `tox-travis`** (https://tox-travis.readthedocs.io/en/stable/) to simplify test suite.

Previously we defined complicated matrix in Travis config to run all possible version and service variations we have. Now this package handles all that, we only need to specify which python versions to run against. This looks much cleaner and simpler to maintain.

Linting tasks are running under python 3.6 environment since version does not really matter here (instead of having expensive separate job).

2. I **migrated** this repo **from travis-ci.org**, which is deprecated now, to **travis-ci.com**, which is now a single source for all repositories (public and private).
3. I **upgraded to PostgreSQL 10** in our CI, since 9.6 is being deprecated.
