### PR TITLE
Revert "is_deleted field should have an index (#85)"

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -10,8 +10,3 @@ Salesforce
 serializable
 subclasses
 superclass
-Admin
-admins
-heroku
-hc
-DateTime

--- a/heroku_connect/contrib/heroku_connect_health_check/__init__.py
+++ b/heroku_connect/contrib/heroku_connect_health_check/__init__.py
@@ -10,6 +10,7 @@ Simply add the following to your ``INSTALLED_APPS`` setting::
     ]
 
 Note:
+
     This features requires `django-health-check`_ to be installed.
 
 .. _`django-health-check`: https://github.com/KristianOellegaard/django-health-check

--- a/heroku_connect/db/models/base.py
+++ b/heroku_connect/db/models/base.py
@@ -88,6 +88,7 @@ class HerokuConnectModel(_HerokuConnectSnitchMixin, models.Model,
     Base model for Heroku Connect enabled ORM models in Django.
 
     Example::
+
         from heroku_connect.db import models as hc_models
 
 
@@ -97,6 +98,7 @@ class HerokuConnectModel(_HerokuConnectSnitchMixin, models.Model,
             custom_date = hc_models.DateTime(sf_field_name='Custom_Date__c')
 
     Note:
+
         Subclasses have :attr:`Meta.managed<django.db.models.Options.managed>` set to ``False``.
 
         A default value for :attr:`Meta.db_table<django.db.models.Options.db_table>` is set based
@@ -104,11 +106,13 @@ class HerokuConnectModel(_HerokuConnectSnitchMixin, models.Model,
         and :attr:`.sf_object_name`.
 
     Note:
+
         A model mixin must inherit from :class:`Meta.managed<django.db.models.Model>`
         not `.HerokuConnectModel`. Only the final (not abstract) models should inherit
         from `.HerokuConnectModel` otherwise build-in fields will clash.
 
     Warning:
+
         The Salesforce `User`_ and `RecordType`_ objects have no ``IsDeleted`` field. Therefore
         if :attr:`.sf_object_name` is set to ``User`` or ``RecordType``
         the Django ORM representation does not have this field either.
@@ -163,7 +167,7 @@ class HerokuConnectModel(_HerokuConnectSnitchMixin, models.Model,
 
     sf_id = fields.ID(sf_field_name='Id', db_column='sfid')
     system_mod_stamp = fields.DateTime(sf_field_name='SystemModstamp', db_index=True)
-    is_deleted = fields.Checkbox(sf_field_name='IsDeleted', db_index=True)
+    is_deleted = fields.Checkbox(sf_field_name='IsDeleted')
     _hc_lastop = models.CharField(
         max_length=32, null=True, editable=False,
         help_text='Indicates the last sync operation Heroku Connect performed on the record',

--- a/tests/db/models/test_base.py
+++ b/tests/db/models/test_base.py
@@ -82,7 +82,6 @@ class TestHerokuConnectModelMixin:
                     },
                     'indexes': {
                         'Id': {'unique': True},
-                        'IsDeleted': {'unique': False},
                         'SystemModstamp': {'unique': False},
                     },
                     'sf_max_daily_api_calls': 30000,
@@ -119,7 +118,6 @@ class TestHerokuConnectModelMixin:
                     },
                     'indexes': {
                         'Id': {'unique': True},
-                        'IsDeleted': {'unique': False},
                         'SystemModstamp': {'unique': False},
                         'Date1__c': {'unique': False},
                         'Date2__c': {'unique': True},
@@ -155,7 +153,6 @@ class TestHerokuConnectModelMixin:
                     },
                     'indexes': {
                         'Id': {'unique': True},
-                        'IsDeleted': {'unique': False},
                         'SystemModstamp': {'unique': False},
                         'Date__c': {'unique': True},
                     },
@@ -188,7 +185,6 @@ class TestHerokuConnectModelMixin:
                     },
                     'indexes': {
                         'Id': {'unique': True},
-                        'IsDeleted': {'unique': False},
                         'SystemModstamp': {'unique': False},
                     },
                     'sf_max_daily_api_calls': 30000,
@@ -374,7 +370,6 @@ class TestHerokuConnectModelMixin:
                     },
                     'indexes': {
                         'Id': {'unique': True},
-                        'IsDeleted': {'unique': False},
                         'SystemModstamp': {'unique': False},
                         'Number__c': {'unique': True},
                     },

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,7 +79,6 @@ def test_get_mapping(settings):
                    },
                    'indexes': {
                        'Id': {'unique': True},
-                       'IsDeleted': {'unique': False},
                        'SystemModstamp': {'unique': False},
                        'External_ID': {'unique': True},
                    },
@@ -101,7 +100,6 @@ def test_get_mapping(settings):
                    },
                    'indexes': {
                        'Id': {'unique': True},
-                       'IsDeleted': {'unique': False},
                        'SystemModstamp': {'unique': False}
                    },
                    'sf_max_daily_api_calls': 30000,


### PR DESCRIPTION
This reverts commit adfac9be2756115c091d0f28605871179aec3123.

as discussed in https://github.com/Thermondo/thermondo-backend/pull/13998 we actually don't need this any more, and the use-case for other users doesn't exist. 

Heroku Support explanation:

```
Thanks for reaching out.

>Am I safe to assume that Heroku Connect deletes the records in postgres that are trashed in Salesforce? Is the column used only temporarily?

You're correct - we need to clarify this in the documentation. We use the isDeleted field under the hood in sync operations, but as soon as a record is soft-deleted in Salesforce, we hard-delete it from Postgres. So deleted records will get removed from the Postgres table altogether.

>If yes, what's the time between the deleted record appearing and it being deleted?

It would happen in the normal sync process, so, within 2 minutes if using normal polling, or as the change is made if using accelerating polling/streaming API.

Hope that helps, please let us know is we can assist further.
```
