### PR TITLE
use recapture when doing `redo` on ordered-write errors

### DIFF
--- a/heroku_connect/models.py
+++ b/heroku_connect/models.py
@@ -90,6 +90,7 @@ class TriggerLogAbstract(models.Model):
     # `id` is a BigAutoField for testing convenience;  in a real environment, id management
     # is up to Heroku Connect.
     id = models.BigAutoField(primary_key=True, editable=False)
+    txid = models.BigIntegerField(editable=False, null=True)
     created_at = models.DateTimeField(editable=False, null=True)
     updated_at = models.DateTimeField(editable=False, null=True)
     processed_at = models.DateTimeField(editable=False, null=True)
@@ -170,6 +171,9 @@ class TriggerLogAbstract(models.Model):
         )
         params = {'record_id': record_id, 'table_name': table_name}
         result_qs = TriggerLog.objects.raw(raw_query, params)
+        if not result_qs:
+            raise TriggerLog.DoesNotExist("TriggerLog was not created after re-capturing INSERT")
+
         return list(result_qs)  # don't expose raw query; clients only care about the log entries
 
     @classmethod
@@ -212,6 +216,8 @@ class TriggerLogAbstract(models.Model):
         )
         params = {'record_id': record_id, 'table_name': table_name}
         result_qs = TriggerLog.objects.raw(raw_query, params)
+        if not result_qs:
+            raise TriggerLog.DoesNotExist("TriggerLog was not created after re-capturing UPDATE")
         return list(result_qs)  # don't expose raw query; clients only care about the log entries
 
     def __str__(self):

--- a/heroku_connect/models.py
+++ b/heroku_connect/models.py
@@ -5,7 +5,10 @@ from django.db import models, transaction
 from django.utils.translation import ugettext_lazy as _
 from psycopg2 import sql
 
-from heroku_connect.utils import get_connected_model_for_table_name
+from heroku_connect.utils import (
+    WriteAlgorithm, get_connected_model_for_table_name,
+    get_unique_connection_write_mode
+)
 
 
 class TriggerLogQuerySet(models.QuerySet):
@@ -255,13 +258,13 @@ class TriggerLogAbstract(models.Model):
                                               update_fields=update_fields)
 
     def _recapture(self):
-        if self.action == 'INSERT': 
+        if self.action == 'INSERT':
             self.capture_insert()
             return True
 
         elif self.action == 'UPDATE':
-            self.capture_update() 
-            return True 
+            self.capture_update()
+            return True
 
         else:
             return False

--- a/heroku_connect/utils.py
+++ b/heroku_connect/utils.py
@@ -269,7 +269,7 @@ def get_connection_write_mode(connection_id):
 @lru_cache
 def get_unique_connection_write_mode(app_name=None):
     app_name = app_name or settings.HEROKU_CONNECT_APP_NAME
-    mode, = set(get_all_connections_write_modes(app_name))
+    mode, = set(get_all_connections_write_modes(app_name).values())
 
     return mode
 

--- a/heroku_connect/utils.py
+++ b/heroku_connect/utils.py
@@ -27,16 +27,17 @@ class ConnectionStates:
         BUSY,
     )
 
+
 class WriteAlgorithm(Enum):
     MERGE_WRITES = 1
     ORDERED_WRITES = 2
 
 
 def _write_algorithm_from_connection_info(info):
-    if info['features'].get('poll_db_no_merge', False):
+    if info.get('features', {}).get('poll_db_no_merge', False):
         return WriteAlgorithm.ORDERED_WRITES
     else:
-        return WriteAlgorithm.MERGE_WRITES 
+        return WriteAlgorithm.MERGE_WRITES
 
 
 def get_mapping(version=1, exported_at=None, app_name=None):
@@ -199,8 +200,8 @@ def get_connections(app):
 
 
 def get_all_connections_write_modes(app):
-    return { 
-        info['id']: write_algorithm_from_connection_info(info) 
+    return {
+        info['id']: _write_algorithm_from_connection_info(info)
         for info in get_connections(app)
     }
 
@@ -265,10 +266,10 @@ def get_connection_write_mode(connection_id):
     )
 
 
+@lru_cache
 def get_unique_connection_write_mode(app_name=None):
-    # TODO: add caching? 
     app_name = app_name or settings.HEROKU_CONNECT_APP_NAME
-    mode, = set(get_all_connections_write_modes(app_name)) 
+    mode, = set(get_all_connections_write_modes(app_name))
 
     return mode
 

--- a/heroku_connect/utils.py
+++ b/heroku_connect/utils.py
@@ -1,5 +1,6 @@
 """Utility methods for Django Heroku Connect."""
 import os
+from enum import Enum
 from functools import lru_cache
 
 import requests
@@ -25,6 +26,17 @@ class ConnectionStates:
         IMPORT_CONFIGURATION,
         BUSY,
     )
+
+class WriteAlgorithm(Enum):
+    MERGE_WRITES = 1
+    ORDERED_WRITES = 2
+
+
+def _write_algorithm_from_connection_info(info):
+    if info['features'].get('poll_db_no_merge', False):
+        return WriteAlgorithm.ORDERED_WRITES
+    else:
+        return WriteAlgorithm.MERGE_WRITES 
 
 
 def get_mapping(version=1, exported_at=None, app_name=None):
@@ -186,6 +198,13 @@ def get_connections(app):
     return response.json()['results']
 
 
+def get_all_connections_write_modes(app):
+    return { 
+        info['id']: write_algorithm_from_connection_info(info) 
+        for info in get_connections(app)
+    }
+
+
 def get_connection(connection_id, deep=False):
     """
     Get Heroku Connection connection information.
@@ -238,6 +257,20 @@ def get_connection(connection_id, deep=False):
     response = requests.get(url, params=payload, headers=_get_authorization_headers())
     response.raise_for_status()
     return response.json()
+
+
+def get_connection_write_mode(connection_id):
+    return _write_algorithm_from_connection_info(
+        get_connection(connection_id)
+    )
+
+
+def get_unique_connection_write_mode(app_name=None):
+    # TODO: add caching? 
+    app_name = app_name or settings.HEROKU_CONNECT_APP_NAME
+    mode, = set(get_all_connections_write_modes(app_name)) 
+
+    return mode
 
 
 def import_mapping(connection_id, mapping):

--- a/heroku_connect/utils.py
+++ b/heroku_connect/utils.py
@@ -266,7 +266,7 @@ def get_connection_write_mode(connection_id):
     )
 
 
-@lru_cache
+@lru_cache()
 def get_unique_connection_write_mode(app_name=None):
     app_name = app_name or settings.HEROKU_CONNECT_APP_NAME
     mode, = set(get_all_connections_write_modes(app_name).values())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,18 +45,81 @@ def make_trigger_log(*, is_archived=False, **attrs):
 
 
 @pytest.fixture 
-def hc_capture_stored_procedured(db):
-    pass
-    # method code taken from a database with enabled HC, not necessarily 
-    # updated
+def hc_capture_stored_procedures(db, settings):
+    # to capture: 
+    # > select routine_definition from information_schema.routines where routine_name = 'hc_capture_insert_from_row'; 
+    # parameters following https://dataedo.com/kb/query/postgresql/list-stored-procedure-parameters
 
-    # with connection.cursor() as cursor:
-    #     cursor.execute("UPDATE bar SET foo = 1 WHERE baz = %s", [self.baz])
-    #     cursor.execute("SELECT foo FROM bar WHERE baz = %s", [self.baz])
+    with connection.cursor() as cursor:
+        cursor.execute(f""" 
+            CREATE OR REPLACE FUNCTION {settings.HEROKU_CONNECT_SCHEMA}.hc_capture_insert_from_row (source_row hstore, table_name text, excluded_cols text[] default ARRAY[]::text[])
+            RETURNS int 
+            LANGUAGE plpgsql
+            AS $$
 
+            DECLARE                                                                      
+                excluded_cols_standard text[] = ARRAY['_hc_lastop', '_hc_err']::text[];  
+                retval int;                                                              
+                                                                                   
+            BEGIN                                                                        
+                -- VERSION 1 --                                                          
+                                                                                       
+                IF (source_row -> 'id') IS NULL THEN                                     
+                    -- source_row is required to have an int id value                    
+                    RETURN NULL;                                                         
+                END IF;                                                                  
+                                                                                       
+                excluded_cols_standard := array_remove(                                  
+                    array_remove(excluded_cols, 'id'), 'sfid') || excluded_cols_standard;
+                INSERT INTO "salesforce"."_trigger_log" (                                
+                    action, table_name, txid, created_at, state, record_id, values)      
+                VALUES (                                                                 
+                    'INSERT', table_name, txid_current(), clock_timestamp(), 'NEW',      
+                    (source_row -> 'id')::int,                                           
+                    source_row - excluded_cols_standard                                  
+                ) RETURNING id INTO retval;                                              
+                RETURN retval;                                                           
+            END;                                                 
+            $$
+        """)
 
+        cursor.execute(f""" 
+            CREATE OR REPLACE FUNCTION {settings.HEROKU_CONNECT_SCHEMA}.hc_capture_update_from_row (source_row hstore, table_name text, columns_to_include text[] default ARRAY[]::text[])
+            RETURNS int 
+            LANGUAGE plpgsql
+            AS $$
+            DECLARE
+                excluded_cols_standard text[] = ARRAY['_hc_lastop', '_hc_err']::text[];
+                excluded_cols text[];
+                retval int;
 
+            BEGIN 
+                -- VERSION 1 --
+                                                                                                            
+                IF (source_row -> 'id') IS NULL THEN
+                    -- source_row is required to have an int id value
+                    RETURN NULL;
+                END IF;
 
+                IF array_length(columns_to_include, 1) <> 0 THEN 
+                    excluded_cols := array(
+                        select skeys(source_row)
+                        except
+                        select unnest(columns_to_include)
+                    );                                                                                         
+                END IF;
+                excluded_cols_standard := excluded_cols || excluded_cols_standard;
+                INSERT INTO "salesforce"."_trigger_log" (
+                   action, table_name, txid, created_at, state, record_id, sfid, values, old)
+                VALUES (
+                   'UPDATE', table_name, txid_current(), clock_timestamp(), 'NEW',
+                   (source_row -> 'id')::int, source_row -> 'sfid',
+                   source_row - excluded_cols_standard, NULL
+                ) RETURNING id INTO retval;
+                RETURN retval;
+                END;
+            $$
+        """)
 
 @pytest.fixture()
 def connected_class():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,48 +44,51 @@ def make_trigger_log(*, is_archived=False, **attrs):
     return model_cls(**attrs)
 
 
-@pytest.fixture 
+@pytest.fixture
 def hc_capture_stored_procedures(db, settings):
-    # to capture: 
-    # > select routine_definition from information_schema.routines where routine_name = 'hc_capture_insert_from_row'; 
+    # to capture:
+    # > select routine_definition from information_schema.routines
+    # > where routine_name = 'hc_capture_insert_from_row';
     # parameters following https://dataedo.com/kb/query/postgresql/list-stored-procedure-parameters
 
     with connection.cursor() as cursor:
-        cursor.execute(f""" 
-            CREATE OR REPLACE FUNCTION {settings.HEROKU_CONNECT_SCHEMA}.hc_capture_insert_from_row (source_row hstore, table_name text, excluded_cols text[] default ARRAY[]::text[])
-            RETURNS int 
+        cursor.execute(f"""
+            CREATE OR REPLACE FUNCTION {settings.HEROKU_CONNECT_SCHEMA}.hc_capture_insert_from_row
+                (source_row hstore, table_name text, excluded_cols text[] default ARRAY[]::text[])
+            RETURNS int
             LANGUAGE plpgsql
             AS $$
 
-            DECLARE                                                                      
-                excluded_cols_standard text[] = ARRAY['_hc_lastop', '_hc_err']::text[];  
-                retval int;                                                              
-                                                                                   
-            BEGIN                                                                        
-                -- VERSION 1 --                                                          
-                                                                                       
-                IF (source_row -> 'id') IS NULL THEN                                     
-                    -- source_row is required to have an int id value                    
-                    RETURN NULL;                                                         
-                END IF;                                                                  
-                                                                                       
-                excluded_cols_standard := array_remove(                                  
+            DECLARE
+                excluded_cols_standard text[] = ARRAY['_hc_lastop', '_hc_err']::text[];
+                retval int;
+
+            BEGIN
+                -- VERSION 1 --
+
+                IF (source_row -> 'id') IS NULL THEN
+                    -- source_row is required to have an int id value
+                    RETURN NULL;
+                END IF;
+
+                excluded_cols_standard := array_remove(
                     array_remove(excluded_cols, 'id'), 'sfid') || excluded_cols_standard;
-                INSERT INTO "salesforce"."_trigger_log" (                                
-                    action, table_name, txid, created_at, state, record_id, values)      
-                VALUES (                                                                 
-                    'INSERT', table_name, txid_current(), clock_timestamp(), 'NEW',      
-                    (source_row -> 'id')::int,                                           
-                    source_row - excluded_cols_standard                                  
-                ) RETURNING id INTO retval;                                              
-                RETURN retval;                                                           
-            END;                                                 
+                INSERT INTO "salesforce"."_trigger_log" (
+                    action, table_name, txid, created_at, state, record_id, values)
+                VALUES (
+                    'INSERT', table_name, txid_current(), clock_timestamp(), 'NEW',
+                    (source_row -> 'id')::int,
+                    source_row - excluded_cols_standard
+                ) RETURNING id INTO retval;
+                RETURN retval;
+            END;
             $$
         """)
 
-        cursor.execute(f""" 
-            CREATE OR REPLACE FUNCTION {settings.HEROKU_CONNECT_SCHEMA}.hc_capture_update_from_row (source_row hstore, table_name text, columns_to_include text[] default ARRAY[]::text[])
-            RETURNS int 
+        cursor.execute(f"""
+            CREATE OR REPLACE FUNCTION {settings.HEROKU_CONNECT_SCHEMA}.hc_capture_update_from_row
+            (source_row hstore, table_name text, columns_to_include text[] default ARRAY[]::text[])
+            RETURNS int
             LANGUAGE plpgsql
             AS $$
             DECLARE
@@ -93,20 +96,20 @@ def hc_capture_stored_procedures(db, settings):
                 excluded_cols text[];
                 retval int;
 
-            BEGIN 
+            BEGIN
                 -- VERSION 1 --
-                                                                                                            
+
                 IF (source_row -> 'id') IS NULL THEN
                     -- source_row is required to have an int id value
                     RETURN NULL;
                 END IF;
 
-                IF array_length(columns_to_include, 1) <> 0 THEN 
+                IF array_length(columns_to_include, 1) <> 0 THEN
                     excluded_cols := array(
                         select skeys(source_row)
                         except
                         select unnest(columns_to_include)
-                    );                                                                                         
+                    );
                 END IF;
                 excluded_cols_standard := excluded_cols || excluded_cols_standard;
                 INSERT INTO "salesforce"."_trigger_log" (
@@ -120,6 +123,7 @@ def hc_capture_stored_procedures(db, settings):
                 END;
             $$
         """)
+
 
 @pytest.fixture()
 def connected_class():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import json
+
+import httpretty
 import pytest
 from django.db import connection
 from django.utils import timezone
@@ -6,6 +9,7 @@ from heroku_connect.db.models.base import READ_WRITE, HerokuConnectModel
 from heroku_connect.models import (
     TRIGGER_LOG_ACTION, TRIGGER_LOG_STATE, TriggerLog, TriggerLogArchive
 )
+from tests import fixtures
 
 
 def make_trigger_log_for_model(model, *, is_archived=False, **kwargs):
@@ -96,3 +100,23 @@ def failed_trigger_log(connected_model):
     return make_trigger_log_for_model(connected_model,
                                       is_archived=False,
                                       state=TRIGGER_LOG_STATE['FAILED'])
+
+
+@pytest.yield_fixture
+def set_write_mode_merge():
+    httpretty.register_uri(
+        httpretty.GET,
+        'https://connect-eu.heroku.com/api/v3/connections',
+        body=json.dumps(fixtures.connection),
+        status=200,
+        content_type='application/json',
+    )
+    with httpretty.enabled():
+        yield
+
+    # httpretty.register_uri(
+    #     httpretty.GET, "https://connect-eu.heroku.com/api/v3/connections",
+    #     body=json.dumps(fixtures.connections),
+    #     status=200,
+    #     content_type='application/json',
+    # )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,20 @@ def make_trigger_log(*, is_archived=False, **attrs):
     return model_cls(**attrs)
 
 
+@pytest.fixture 
+def hc_capture_stored_procedured(db):
+    pass
+    # method code taken from a database with enabled HC, not necessarily 
+    # updated
+
+    # with connection.cursor() as cursor:
+    #     cursor.execute("UPDATE bar SET foo = 1 WHERE baz = %s", [self.baz])
+    #     cursor.execute("SELECT foo FROM bar WHERE baz = %s", [self.baz])
+
+
+
+
+
 @pytest.fixture()
 def connected_class():
     """Get a HerokuConnectedModel subclass"""

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -119,7 +119,7 @@ class TestAdminActions:
 
     @pytest.mark.parametrize('log_action', TRIGGER_LOG_ACTION.values())
     def test_retry_failed_logs_ordered_write(
-            self, log_action, admin_client, set_write_mode_ordered, 
+            self, log_action, admin_client, set_write_mode_ordered,
             hc_capture_stored_procedures):
 
         assert get_unique_connection_write_mode() == WriteAlgorithm.ORDERED_WRITES
@@ -204,7 +204,7 @@ class TestAdminActions:
 
     @pytest.mark.parametrize('log_action', TRIGGER_LOG_ACTION.values())
     def test_retry_failed_logs_in_archive_ordered_write(
-            self, log_action, admin_client, set_write_mode_ordered, 
+            self, log_action, admin_client, set_write_mode_ordered,
             hc_capture_stored_procedures):
 
         assert get_unique_connection_write_mode() == WriteAlgorithm.ORDERED_WRITES

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -122,6 +122,7 @@ class TestAdminActions:
         failed_logs = TriggerLog.objects.bulk_create([
             make_trigger_log(
                 state=TRIGGER_LOG_STATE['FAILED'],
+                table_name='number_object__c',
                 record_id=i,
                 action=action,
             )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,7 +56,7 @@ class TestTriggerLog:
 
         with pytest.raises(TriggerLog.DoesNotExist):
             failed_log.capture_update()
-            
+
     def test_capture_update_wrong_update_field(self, trigger_log, hc_capture_stored_procedures):
         with pytest.raises(FieldDoesNotExist):
             trigger_log.capture_update(update_fields=('NOT A FIELD',))


### PR DESCRIPTION
# what we are doing 
- for `OrderedWrites`, the [heroku docs](https://devcenter.heroku.com/articles/writing-data-to-salesforce-with-heroku-connect#ordered-writes-algorithm) state that retrying should be done through `hc_capture_insert_from_row` and `hc_capture_update_from_row`. 
- now we are doing this

# what I already tested manually
- update passes
- update fails with validation rule
- retry of update fails again (but is creating a new trigger-log record)
- retry passes when validation rule is dropped / fixed

and the same for insert