### PR TITLE
Replace deprecated Django ugettext_lazy

### DIFF
--- a/heroku_connect/admin.py
+++ b/heroku_connect/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from django.db import transaction
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from heroku_connect.models import (
     TRIGGER_LOG_STATE, TriggerLog, TriggerLogArchive

--- a/heroku_connect/models.py
+++ b/heroku_connect/models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core import checks
 from django.db import models, transaction
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from psycopg2 import sql
 
 from heroku_connect.utils import (

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from heroku_connect.db import models as hc_models
 


### PR DESCRIPTION
...with `gettext_lazy`

```
RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
```