### PR TITLE
Update CI test matrix: Add Django 3.2, drop Python 3.6, Django 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     services:
       postgresql:

--- a/tests/db/models/test_base.py
+++ b/tests/db/models/test_base.py
@@ -246,11 +246,11 @@ class TestHerokuConnectModelMixin:
         ) not in errors
 
     def test_check_sf_object_name_concrete(self):
-        # the check for concrete models breaks when we try to use a 
-        # temporary `MyClass`, because `model._meta.app_config` is 
-        # invalid when just definiting `Meta.app_label`. 
-        # So for this test we just use an existing model and break 
-        # it. 
+        # the check for concrete models breaks when we try to use a
+        # temporary `MyClass`, because `model._meta.app_config` is
+        # invalid when just definiting `Meta.app_label`.
+        # So for this test we just use an existing model and break
+        # it.
         setattr(NumberModel, 'sf_object_name', None)
 
         errors = NumberModel.check()

--- a/tests/db/models/test_base.py
+++ b/tests/db/models/test_base.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from heroku_connect.db import models as hc_models
 from heroku_connect.db.exceptions import WriteNotSupportedError
+from tests.testapp.models import NumberModel
 
 
 class TestHerokuConnectModelMixin:
@@ -232,7 +233,7 @@ class TestHerokuConnectModelMixin:
             None
         )
 
-    def test_check_sf_object_name(self):
+    def test_check_sf_object_name_abstract(self):
         class MyModel(hc_models.HerokuConnectModel):
             class Meta:
                 app_label = 'test'
@@ -244,13 +245,17 @@ class TestHerokuConnectModelMixin:
             id='heroku_connect.E001',
         ) not in errors
 
-        class MyModel(hc_models.HerokuConnectModel):
-            class Meta:
-                app_label = 'test'
+    def test_check_sf_object_name_concrete(self):
+        # the check for concrete models breaks when we try to use a 
+        # temporary `MyClass`, because `model._meta.app_config` is 
+        # invalid when just definiting `Meta.app_label`. 
+        # So for this test we just use an existing model and break 
+        # it. 
+        setattr(NumberModel, 'sf_object_name', None)
 
-        errors = MyModel.check()
+        errors = NumberModel.check()
         assert errors == [checks.Error(
-            "test.MyModel must define a \"sf_object_name\".",
+            "testapp.NumberModel must define a \"sf_object_name\".",
             id='heroku_connect.E001',
         )]
 
@@ -388,7 +393,6 @@ class TestHerokuConnectModelMixin:
 
             class Meta:
                 app_label = 'test'
-                abstract = True
 
         data_instance = MyReadOnlyModel(date=timezone.now())
         with pytest.raises(WriteNotSupportedError) as e:

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -120,6 +120,8 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 
 HEROKU_CONNECT_APP_NAME = 'ninja'
 HEROKU_CONNECT_ORGANIZATION_ID = '1234567890'

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,9 @@ python =
 [testenv]
 deps=
     -rrequirements-dev.txt
-    dj22: Django==2.2
-    dj31: Django>=3.1,<3.2
-    dj32: Django>=3.2,<3.3
+    dj22: Django~=2.2
+    dj30: Django~=3.1
+    dj31: Django~=3.2
 setenv =
     PYTHONPATH = {toxinidir}
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ python =
 deps=
     -rrequirements-dev.txt
     dj22: Django~=2.2
-    dj30: Django~=3.1
-    dj31: Django~=3.2
+    dj31: Django~=3.1
+    dj32: Django~=3.2
 setenv =
     PYTHONPATH = {toxinidir}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,30,31}
+    py{37,38,39}-dj{22,31,32}
     isort
     docs
 whitelist_externals=sphinx-build
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39,isort,docs
@@ -15,9 +14,9 @@ python =
 [testenv]
 deps=
     -rrequirements-dev.txt
-    dj22: django>=2.2a1,<3.0
-    dj30: django>=3.0a1,<3.1
-    dj31: django>=3.1a1,<3.2
+    dj22: Django==2.2
+    dj31: Django>=3.1,<3.2
+    dj32: Django>=3.2,<3.3
 setenv =
     PYTHONPATH = {toxinidir}
 


### PR DESCRIPTION
In 3.2 primary_keys behaviour changed a bit:
https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys

This is affecting our tests, need to dig deeper into it.