### PR TITLE
Add Django 3.2 support, drop 3.0. Set minimal Django version to 2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django-appconf
-django>=1.11.0
+django>=2.2
 requests

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,30,31}
+    py{36,37,38,39}-django{22,31,32}
     isort
     docs
 whitelist_externals=sphinx-build
@@ -15,9 +15,9 @@ python =
 [testenv]
 deps=
     -rrequirements-dev.txt
-    dj22: django>=2.2a1,<3.0
-    dj30: django>=3.0a1,<3.1
-    dj31: django>=3.1a1,<3.2
+    django22: Django==2.2
+    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
 setenv =
     PYTHONPATH = {toxinidir}
 


### PR DESCRIPTION
To match with currently supported/LTS versions.