### PR TITLE
Convert Composed query to str before running raw query

### DIFF
--- a/heroku_connect/models.py
+++ b/heroku_connect/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.db import models, transaction
+from django.db import connections, models, router, transaction
 from django.utils.translation import gettext_lazy as _
 from psycopg2 import sql
 
@@ -156,7 +156,7 @@ class TriggerLogAbstract(models.Model):
             model_cls = get_connected_model_for_table_name(table_name)
             exclude_cols = cls._fieldnames_to_colnames(model_cls, exclude_fields)
 
-        raw_query = sql.SQL(
+        composable_query = sql.SQL(
             """
             SELECT {schema}.hc_capture_insert_from_row(
               hstore({schema}.{table_name}.*),
@@ -174,7 +174,9 @@ class TriggerLogAbstract(models.Model):
             ),
         )
         params = {"record_id": record_id, "table_name": table_name}
-        result_qs = TriggerLog.objects.raw(raw_query, params)
+        raw_sql = cls._compile_sql(TriggerLog, composable_query)
+        result_qs = TriggerLog.objects.raw(raw_sql, params)
+
         if not result_qs:
             raise TriggerLog.DoesNotExist(
                 "TriggerLog was not created after re-capturing INSERT"
@@ -214,7 +216,7 @@ class TriggerLogAbstract(models.Model):
             model_cls = get_connected_model_for_table_name(table_name)
             include_cols.update(cls._fieldnames_to_colnames(model_cls, update_fields))
 
-        raw_query = sql.SQL(
+        composable_query = sql.SQL(
             """
             SELECT {schema}.hc_capture_update_from_row(
               hstore({schema}.{table_name}.*),
@@ -233,7 +235,8 @@ class TriggerLogAbstract(models.Model):
             "table_name": table_name,
             "include_cols": list(include_cols),
         }
-        result_qs = TriggerLog.objects.raw(raw_query, params)
+        raw_sql = cls._compile_sql(TriggerLog, composable_query)
+        result_qs = TriggerLog.objects.raw(raw_sql, params)
         if not result_qs:
             raise TriggerLog.DoesNotExist(
                 "TriggerLog was not created after re-capturing UPDATE"
@@ -319,6 +322,13 @@ class TriggerLogAbstract(models.Model):
         get_field = model_cls._meta.get_field
         fields = map(get_field, fieldnames)
         return {f.column for f in fields}
+
+    @staticmethod
+    def _compile_sql(model_cls, composable_query):
+        db_name = router.db_for_read(model_cls)
+        with connections[db_name].cursor().cursor as cursor:
+            return composable_query.as_string(cursor)
+
 
 
 class TriggerLog(TriggerLogAbstract):

--- a/heroku_connect/models.py
+++ b/heroku_connect/models.py
@@ -330,7 +330,6 @@ class TriggerLogAbstract(models.Model):
             return composable_query.as_string(cursor)
 
 
-
 class TriggerLog(TriggerLogAbstract):
     """
     Represents entries in the Heroku Connect trigger log.


### PR DESCRIPTION
[ScoutAPM](https://scoutapm.com) breaks when it tries to measure query performance on raw queries that use [psycopg2's SQL string composition](https://www.psycopg.org/docs/sql.html). This is a workaround to convert composed queries to strings before running the raw query.

Submitted issue with Scout here: https://github.com/scoutapp/scout_apm_python/issues/749