### PR TITLE
Update Actions to resolve warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,19 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install package dependencies
       run: |
         sudo apt-get install -y gdal-bin
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
 
     - name: restore pip download cache
       uses: syphar/restore-pip-download-cache@v1
 
     - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v2.1.0
+      uses: py-actions/py-dependency-install@v4
       with:
         path: "requirements-dev.txt"
 
@@ -39,19 +39,19 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install package dependencies
       run: |
         sudo apt-get install -y gdal-bin
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
 
     - name: restore pip download cache
       uses: syphar/restore-pip-download-cache@v1
 
     - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v2.1.0
+      uses: py-actions/py-dependency-install@v4
       with:
         path: "requirements-dev.txt"
 
@@ -77,19 +77,19 @@ jobs:
         - 5432:5432
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install package dependencies
       run: |
         sudo apt-get install -y gdal-bin
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v2.1.0
+      uses: py-actions/py-dependency-install@v4
       with:
         path: "requirements-dev.txt"
 
@@ -113,6 +113,6 @@ jobs:
       # the codecov github action needs this package to find the reports
       run: pip install coverage
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       uses: syphar/restore-pip-download-cache@v1
 
     - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v4
+      uses: py-actions/py-dependency-install@v2.1.0
       with:
         path: "requirements-dev.txt"
 
@@ -51,7 +51,7 @@ jobs:
       uses: syphar/restore-pip-download-cache@v1
 
     - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v4
+      uses: py-actions/py-dependency-install@v2.1.0
       with:
         path: "requirements-dev.txt"
 
@@ -89,7 +89,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v4
+      uses: py-actions/py-dependency-install@v2.1.0
       with:
         path: "requirements-dev.txt"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         sudo apt-get install -y gdal-bin
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v3
 
     - name: restore pip download cache
       uses: syphar/restore-pip-download-cache@v1
@@ -45,7 +45,7 @@ jobs:
         sudo apt-get install -y gdal-bin
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v3
 
     - name: restore pip download cache
       uses: syphar/restore-pip-download-cache@v1
@@ -84,7 +84,7 @@ jobs:
         sudo apt-get install -y gdal-bin
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       uses: syphar/restore-pip-download-cache@v1
 
     - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v2.1.0
+      uses: py-actions/py-dependency-install@v4
       with:
         path: "requirements-dev.txt"
 
@@ -51,7 +51,7 @@ jobs:
       uses: syphar/restore-pip-download-cache@v1
 
     - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v2.1.0
+      uses: py-actions/py-dependency-install@v4
       with:
         path: "requirements-dev.txt"
 
@@ -89,7 +89,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install Python dependencies
-      uses: py-actions/py-dependency-install@v2.1.0
+      uses: py-actions/py-dependency-install@v4
       with:
         path: "requirements-dev.txt"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
   package_release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
 
@@ -21,7 +21,7 @@ jobs:
         python setup.py sdist bdist_wheel
 
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_token }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = django-heroku-connect
 author = Thermondo GmbH
-author-email = opensource@thermondo.de
+author_email = opensource@thermondo.de
 summary = Django integration Salesforce using Heroku Connect.
-description-file = README.rst
-home-page = https://github.com/Thermondo/django-heroku-connect
+description_file = README.rst
+home_page = https://github.com/Thermondo/django-heroku-connect
 license = Apache-2
 classifier =
     Development Status :: 4 - Beta


### PR DESCRIPTION
We are getting a few GitHub Actions warnings, at least one of them potentially a security issue.

This should resolve _most_ of our current warnings. A little more work would be required to get everything all the way up-to-date, but this should be good enough for today.