### PR TITLE
extend healthcheck to fail when a single mapping is in a broken state

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ def linkcode_resolve(domain, info):
             pass
         try:
             lines, first_line = inspect.getsourcelines(item)
-            lineno = "#L%d-L%s" % (first_line, first_line + len(lines) - 1)
+            lineno = f"#L{first_line:d}-L{first_line + len(lines) - 1}"
         except (OSError, TypeError):
             pass
     return (

--- a/heroku_connect/contrib/heroku_connect_health_check/backends.py
+++ b/heroku_connect/contrib/heroku_connect_health_check/backends.py
@@ -46,3 +46,20 @@ class HerokuConnectHealthCheck(BaseHealthCheckBackend):
                         )
                     )
                 )
+
+            connection_state = utils.get_connection(connection["id"], deep=True)
+
+            for mapping in connection_state["mappings"]:
+                object_name = mapping["object_name"]
+                state = mapping["state"]
+
+                if (
+                    state in utils.ERROR_MAPPING_STATES
+                    or state in utils.TEMPORARY_ERROR_MAPPING_STATES
+                ):
+                    self.add_error(
+                        ServiceUnavailable(
+                            f"mapping {object_name} on connection {connection['name']} "
+                            f"is in state {state}"
+                        )
+                    )

--- a/heroku_connect/utils.py
+++ b/heroku_connect/utils.py
@@ -1,7 +1,7 @@
 """Utility methods for Django Heroku Connect."""
 
 import os
-from enum import Enum
+from enum import Enum, unique
 from functools import lru_cache
 
 import requests
@@ -30,6 +30,70 @@ class ConnectionStates:
         IMPORT_CONFIGURATION,
         BUSY,
     )
+
+
+@unique
+class MappingState(str, Enum):
+    # https://devcenter.heroku.com/articles/mapping-states-reference#list-of-mapping-states
+    DATA_SYNCED = "DATA_SYNCED"
+    INITIAL = "INITIAL"
+    RESYNC = "RESYNC"
+    RELOAD_TABLE = "RELOAD_TABLE"
+    SCHEMA_CHANGED = "SCHEMA_CHANGED"
+    POLLING_SF_CHANGES = "POLLING_SF_CHANGES"
+    POLLING_SF_BULK = "POLLING_SF_BULK"
+    POLLING_SF_FOR_DELETES = "POLLING_SF_FOR_DELETES"
+    WAIT_BULK_LOAD = "WAIT_BULK_LOAD"
+    LOADING_BULK_JOB = "LOADING_BULK_JOB"
+    RESOLVE_EXTERNAL_IDS = "RESOLVE_EXTERNAL_IDS"
+    BULK_LOAD_ERROR = "BULK_LOAD_ERROR"
+    WAIT_BULK_UPDATE = "WAIT_BULK_UPDATE"
+    APPLYING_BULK_UPDATE = "APPLYING_BULK_UPDATE"
+    POLL_EXTERNAL_IDS = "POLL_EXTERNAL_IDS"
+    RECOVERY = "RECOVERY"
+    ABORTED = "ABORTED"
+    SYSTEM_ERROR = "SYSTEM_ERROR"
+    DB_UNAVAILABLE = "DB_UNAVAILABLE"
+    BAD_CONFIG = "BAD_CONFIG"
+    SYNC_REMOVED = "SYNC_REMOVED"
+    INACTIVE_ORG = "INACTIVE_ORG"
+    UNAUTHORIZED = "UNAUTHORIZED"
+
+
+OK_MAPPING_STATES = (
+    MappingState.DATA_SYNCED,
+    MappingState.RESYNC,
+    MappingState.RELOAD_TABLE,
+    MappingState.POLLING_SF_CHANGES,
+    MappingState.POLLING_SF_BULK,
+    MappingState.POLLING_SF_FOR_DELETES,
+    MappingState.WAIT_BULK_LOAD,
+    MappingState.LOADING_BULK_JOB,
+    MappingState.RESOLVE_EXTERNAL_IDS,
+    MappingState.WAIT_BULK_UPDATE,
+    MappingState.APPLYING_BULK_UPDATE,
+    MappingState.POLL_EXTERNAL_IDS,
+    MappingState.ABORTED,
+)
+
+# mapping states that mean that the sync is not working, but will typically resolve
+# itself
+TEMPORARY_ERROR_MAPPING_STATES = (
+    MappingState.INITIAL,
+    MappingState.SCHEMA_CHANGED,
+    MappingState.RECOVERY,
+)
+
+# mapping states that are permanent errors
+ERROR_MAPPING_STATES = (
+    MappingState.BULK_LOAD_ERROR,
+    MappingState.SYSTEM_ERROR,
+    MappingState.DB_UNAVAILABLE,
+    MappingState.BAD_CONFIG,
+    MappingState.SYNC_REMOVED,
+    MappingState.INACTIVE_ORG,
+    MappingState.UNAUTHORIZED,
+)
 
 
 class WriteAlgorithm(Enum):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -5,7 +5,7 @@ connection = {
     "schema_name": "salesforce",
     "db_key": "DATABASE_URL",
     "state": "IDLE",
-    "mappings": [{"id": "XYZ", "object_name": "Account", "state": "SCHEMA_CHANGED"}],
+    "mappings": [{"id": "XYZ", "object_name": "Account", "state": "DATA_SYNCED"}],
 }
 
 connections = {"count": 1, "results": [connection]}


### PR DESCRIPTION
This is coming from a production problem where a mapping was broken because the related SF field was dropped in SF. 

In this case the sync for that object was completely stopped by Heroku, but we didn't get any notifications for this. 

With this change here we now also check the mapping states and raise errors accordingly, so we would see a down-alert in this case. 