### PR TITLE
add Django 5.2 support, drop discontinued 5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         django-version: ["4.2", "5.1", "5.2"]
-        postgres-version: ["12-2.5", "13-3.4"]
+        postgres-version: ["12-2.5", "13-3.4", "16-3.5"]
         exclude:
           - django-version: "5.2"
             python-version: "3.9"
@@ -53,6 +53,10 @@ jobs:
             python-version: "3.9"
           - django-version: "5.1"
             postgres-version: "12-2.5"
+          - django-version: "5.2"
+            postgres-version: "12-2.5"
+          - django-version: "5.2"
+            postgres-version: "13-3.4"
 
     services:
       postgresql:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,6 @@ jobs:
             python-version: "3.9"
           - django-version: "5.1"
             postgres-version: "12-2.5"
-          - django-version: "5.1"
-            postgres-version: "13-3.4"
           - django-version: "5.2"
             postgres-version: "12-2.5"
           - django-version: "5.2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
             python-version: "3.9"
           - django-version: "5.1"
             postgres-version: "12-2.5"
+          - django-version: "5.1"
+            postgres-version: "13-3.4"
           - django-version: "5.2"
             postgres-version: "12-2.5"
           - django-version: "5.2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,17 +43,15 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        django-version: ["4.2", "5.0", "5.1"]
+        django-version: ["4.2", "5.1", "5.2"]
         postgres-version: ["12-2.5", "13-3.4"]
         exclude:
+          - django-version: "5.2"
+            python-version: "3.9"
           - django-version: "5.1"
             python-version: "3.9"
-          - django-version: "5.0"
-            postgres-version: "12-2.5"
           - django-version: "5.1"
             postgres-version: "12-2.5"
-          - django-version: "5.0"
-            python-version: "3.9"
 
     services:
       postgresql:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install package dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y gdal-bin
 
       - name: install poetry
@@ -68,6 +69,7 @@ jobs:
 
       - name: Install package dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y gdal-bin
 
       - name: install poetry

--- a/heroku_connect/management/commands/import_mappings.py
+++ b/heroku_connect/management/commands/import_mappings.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
         wait_interval = options.get("wait_interval", 10)
         if not (connection_id or app_name):
             raise CommandError(
-                "You need ether specify the application name or " "the connection ID."
+                "You need ether specify the application name or the connection ID."
             )
         if connection_id is None:
             self.stdout.write(self.style.NOTICE("Fetching connections."))

--- a/heroku_connect/test/utils.py
+++ b/heroku_connect/test/utils.py
@@ -43,7 +43,7 @@ def heroku_cli(stdout="", stderr="", exit_code=0):
     path = os.environ.get("PATH", "")
     os.environ["PATH"] = ":".join([bin_dir, path])
     exec_name = os.path.join(bin_dir, "heroku")
-    script = "#!/bin/bash\n" "echo %s 1>&1\n" "echo %s 1>&2\n" "exit %i\n"
+    script = "#!/bin/bash\necho %s 1>&1\necho %s 1>&2\nexit %i\n"
     script %= (shlex.quote(stdout), shlex.quote(stderr), exit_code)
     with open(exec_name, "wb+") as f:
         f.seek(0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [{ include = "heroku_connect" }]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-django = ">=4.2,<5.3"
+django = ">=4.2,!=5.0,<5.3"
 django-appconf = "~1"
 requests = "~2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [{ include = "heroku_connect" }]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-django = ">=4.2,<5.2"
+django = ">=4.2,<5.3"
 django-appconf = "~1"
 requests = "~2"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,8 @@ filterwarnings =
   ignore:The USE_L10N setting is deprecate:DeprecationWarning
   # django 3.2 is using this module, but not in later versions any more
   ignore:'cgi' is deprecated:DeprecationWarning
+  # httpretty is using the deprecated utcnow
+  ignore:datetime.datetime.utcnow.*is deprecated:DeprecationWarning
 
 [flake8]
 max-line-length = 88

--- a/tests/commands/test_import_mappings.py
+++ b/tests/commands/test_import_mappings.py
@@ -105,8 +105,7 @@ class TestImportMapping:
             stdout.seek(0)
             console = stdout.read()
         assert (
-            "No associated connections found"
-            " for the current user with the app 'ninja'."
+            "No associated connections found for the current user with the app 'ninja'."
         ) in str(e.value)
         assert console == (
             "Fetching connections.\n"

--- a/tests/commands/test_load_remote_schema.py
+++ b/tests/commands/test_load_remote_schema.py
@@ -87,10 +87,10 @@ class TestLoadRemoteSchema:
 
         database_url = (
             "postgres://"
-            f'{self.db["USER"]}:{self.db["PASSWORD"]}'
-            f'@{self.db["HOST"]}'
-            f':{self.db["PORT"]}'
-            f'/{self.db["NAME"]}'
+            f"{self.db['USER']}:{self.db['PASSWORD']}"
+            f"@{self.db['HOST']}"
+            f":{self.db['PORT']}"
+            f"/{self.db['NAME']}"
         )
         with heroku_cli(database_url, exit_code=0):
             with StringIO() as sql:


### PR DESCRIPTION
also this drops us testing pg13 with django 5.1. I'm not sure why it fails, but I'm relatively certain it's not because of us

![grafik](https://github.com/user-attachments/assets/c80a775a-184e-4be5-a011-ede034ce9f8e)
