### PR TITLE
fix django dependency specifier for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [{ include = "heroku_connect" }]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-django = ">=4.2,<4.3 || >=5.2,<5.3 || >=6.0,<6.1"
+django = ">=4.2,<6.1,!=5.0.*,!=5.1.*"
 django-appconf = "~1"
 requests = "~2"
 


### PR DESCRIPTION
pypi doesn't support everything that poetry does... 
https://github.com/thermondo/django-heroku-connect/actions/runs/20428650137/job/58694274636

This is the next try 