### PR TITLE
chore: replace dependabot reviewers with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @thermondo/platform

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "06:00"
-    reviewers:
-      - "thermondo/platform"
 
   - package-ecosystem: pip
     directory: "/"
@@ -15,8 +13,6 @@ updates:
       interval: weekly
       day: "monday"
       time: "06:00"
-    reviewers:
-      - "thermondo/platform"
     open-pull-requests-limit: 20
     allow:
       - dependency-type: direct


### PR DESCRIPTION
GitHub deprecated the `reviewers` field on dependabot updates. Adding `.github/CODEOWNERS` so `@thermondo/platform` keeps getting tagged on dependabot PRs, and dropping the obsolete setting.