### PR TITLE
fix: keep django-health-check on the maintained 3.x line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,9 @@ updates:
       - dependency-type: direct
       - dependency-type: indirect
     rebase-strategy: disabled
+    ignore:
+      # django-health-check v4 is a breaking async API rewrite (no plugin_dir,
+      # check_status -> async run()). Stay on the maintained 3.x line; 3.x
+      # patch/minor and security updates still flow.
+      - dependency-name: "django-health-check"
+        update-types: ["version-update:semver-major"]

--- a/heroku_connect/checks.py
+++ b/heroku_connect/checks.py
@@ -17,8 +17,10 @@ def _check_foreign_key(app_configs, **kwargs):
     for model in all_models:
         opts = model._meta
         fks_to_hc_model = filter(
-            lambda f: isinstance(f, (ForeignKey, ManyToManyField))
-            and issubclass(f.remote_field.model, HerokuConnectModel),
+            lambda f: (
+                isinstance(f, (ForeignKey, ManyToManyField))
+                and issubclass(f.remote_field.model, HerokuConnectModel)
+            ),
             opts.local_fields,
         )
 

--- a/heroku_connect/contrib/heroku_connect_health_check/backends.py
+++ b/heroku_connect/contrib/heroku_connect_health_check/backends.py
@@ -8,14 +8,14 @@ from heroku_connect import utils
 from heroku_connect.conf import settings
 
 try:
-    from health_check.backends import BaseHealthCheckBackend
+    from health_check.backends import HealthCheck
     from health_check.exceptions import (
         ServiceReturnedUnexpectedResult,
         ServiceUnavailable,
     )
 except ImportError as e:
     raise ImportError(
-        "django-health-check is needed for this featue, see \
+        "django-health-check is needed for this feature, see \
         http://django-heroku-connect.readthedocs.io/en/latest/contrib.html"
     ) from e
 
@@ -23,8 +23,8 @@ except ImportError as e:
 logger = logging.getLogger("health-check")
 
 
-class HerokuConnectHealthCheck(BaseHealthCheckBackend):
-    def identifier(self):
+class HerokuConnectHealthCheck(HealthCheck):
+    def __repr__(self):
         return "Heroku Connect"
 
     def check_status(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requests = "~2"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "*"
-django-health-check = "*"
+django-health-check = ">=3.21,<4"  # v4 is a breaking async rewrite; stay on the 3.x line
 httpretty = "*"
 pre-commit = "*"
 psycopg2-binary = "*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,11 @@ filterwarnings =
   ignore:'cgi' is deprecated:DeprecationWarning
   # httpretty is using the deprecated utcnow
   ignore:datetime.datetime.utcnow.*is deprecated:DeprecationWarning
+  # django-health-check >= 3.21 deprecates the health_check.urls include and MainView,
+  # but only that legacy path surfaces plugin_dir registrations (how the contrib check
+  # is wired up); the new HealthCheckView takes an explicit checks list instead.
+  ignore:The .health_check.urls. module is deprecated:DeprecationWarning
+  ignore:MainView is deprecated:DeprecationWarning
 
 [flake8]
 max-line-length = 88

--- a/tests/contrib/test_healthcheck.py
+++ b/tests/contrib/test_healthcheck.py
@@ -136,4 +136,6 @@ def test_health_check_url(client):
     )
     response = client.get("/ht/")
     assert response.status_code == 200
-    assert b"<td>Heroku Connect</td>" in response.content
+    # The exact markup differs between django-health-check versions, so just
+    # assert the check's identifier is rendered on the status page.
+    assert b"Heroku Connect" in response.content


### PR DESCRIPTION
Every fresh CI run was red on both `lint` and `tests` because the dev dependencies float (no lockfile): `django-health-check` rolled to **v4**, whose ground-up async rewrite removed `health_check.plugins.plugin_dir`, so `django.setup()` raised `ModuleNotFoundError: No module named 'health_check.plugins'` and every test errored. (A newer `ruff` also reflowed a lambda, failing `ruff_format`.)

Following [thermondo-utils#239](https://github.com/thermondo/thermondo-utils/pull/239): stay on the maintained **3.x** line rather than take on the v4 async migration.

### Changes
- **`pyproject.toml`** — constrain to `>=3.21,<4` (resolves to 3.24.0). 3.21 renamed `BaseHealthCheckBackend` → `HealthCheck` and `identifier()` → `__repr__()`; `plugin_dir` registration and the sync `check_status`/`add_error` API are unchanged, so `apps.py` is untouched.
- **`backends.py`** — subclass `HealthCheck`, use `__repr__`.
- **`setup.cfg`** — `filterwarnings = error`, so ignore the `health_check.urls`/`MainView` deprecations: only that legacy path surfaces `plugin_dir` registrations (how the contrib check is wired up); the new `HealthCheckView` takes an explicit `checks` list instead.
- **`test_healthcheck.py`** — relax the status-page assertion to the version-agnostic `Heroku Connect` identifier (the surrounding markup changed between template versions).
- **`.github/dependabot.yml`** — ignore the `django-health-check` semver-major bump so 3.x updates keep flowing without re-opening v4 PRs.
- **`checks.py`** — apply the ruff reformat (separate commit).

A deliberate migration to the v4 async API can be scheduled separately.

**Verified locally:** `ruff format --check` / `ruff check` clean, and `tests/contrib/test_healthcheck.py` passes against **3.21.1 and 3.24.0** (4 passed each).